### PR TITLE
Expose fromSql method in node-pg

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Get the nearest neighbors to a vector
 const result = await client.query('SELECT * FROM items ORDER BY embedding <-> $1 LIMIT 5', [pgvector.toSql(embedding)]);
 ```
 
-Fetch a vector from the database
+Fetch a vector from the database (if you can't use registerType such as when working with Kysely)
 
 ```javascript
 const result = await client.query('SELECT embedding FROM items WHERE id = $1', [id]);

--- a/README.md
+++ b/README.md
@@ -69,6 +69,28 @@ import pgvector from 'pgvector/pg';
 await pgvector.registerType(client);
 ```
 
+If using pg pool in typescript
+
+```typescript
+import { Pool, types } from 'pg'
+import * as pgvector from 'pgvector/pg';
+
+const pgPool = new Pool({
+  host: "<database ip>",
+  port: "<database port>",
+  database: "<database name>",
+  user: "<database user>",
+  password: "<database pasword",
+})
+
+await pgvector.registerType({
+  setTypeParser: types.setTypeParser,
+  query: async (queryString: string, arg: string[]) => {
+    return await pgPool.query(queryString, arg)
+  },
+})
+```
+
 Insert a vector
 
 ```javascript
@@ -80,6 +102,13 @@ Get the nearest neighbors to a vector
 
 ```javascript
 const result = await client.query('SELECT * FROM items ORDER BY embedding <-> $1 LIMIT 5', [pgvector.toSql(embedding)]);
+```
+
+Fetch a vector from the database
+
+```javascript
+const result = await client.query('SELECT embedding FROM items WHERE id = $1', [id]);
+const embedding = pgvector.fromSql(result.rows[0].embedding);
 ```
 
 ## pg-promise

--- a/src/pg/index.js
+++ b/src/pg/index.js
@@ -18,4 +18,8 @@ function toSql(value) {
   return utils.toSql(value);
 }
 
-module.exports = {registerType, toSql};
+function fromSql(value) {
+  return utils.fromSql(value)
+}
+
+module.exports = {registerType, toSql, fromSql};

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -1,3 +1,3 @@
 export function registerType(client: any): Promise<void>;
-export function toSql(value: any): string;
+export function toSql(value: number[]): string;
 export function fromSql(value: string): number[];

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -1,2 +1,3 @@
 export function registerType(client: any): Promise<void>;
 export function toSql(value: any): string;
+export function fromSql(value: string): number[];


### PR DESCRIPTION
## Changes

* Exposed the `fromSql` method in the node-pg module for manual use cases where setting type doesn't work (like when using with Kysely where the DB schema doesn't have knowledge of the vector type)
* Updated the `toSql` type signature to specify return type in node-pg module
* Updated the README to:
  * Show how to fetch vector from DB using `fromSQL`
  * Show how to setup pgvector-node with node-pg pool in typescript
