### PR TITLE
Add ESM-aware types for pgvector/kysely

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
       "default": "./src/knex/index.js"
     },
     "./kysely": {
-      "types": "./types/kysely/index.d.ts",
+      "types": {
+        "import": "./types/kysely/index.d.mts",
+        "default": "./types/kysely/index.d.ts"
+      },
       "default": "./src/kysely/index.js"
     },
     "./mikro-orm": {

--- a/types/kysely/index.d.mts
+++ b/types/kysely/index.d.mts
@@ -1,0 +1,11 @@
+import type { RawBuilder } from "kysely";
+import { fromSql } from "..";
+import { toSql } from "..";
+
+export function l2Distance(column: any, value: any): RawBuilder<unknown>;
+export function maxInnerProduct(column: any, value: any): RawBuilder<unknown>;
+export function cosineDistance(column: any, value: any): RawBuilder<unknown>;
+export function l1Distance(column: any, value: any): RawBuilder<unknown>;
+export function hammingDistance(column: any, value: any): RawBuilder<unknown>;
+export function jaccardDistance(column: any, value: any): RawBuilder<unknown>;
+export { fromSql, toSql };


### PR DESCRIPTION
## Summary
- add ESM-aware type declarations for `pgvector/kysely` via `index.d.mts`
- wire `exports["./kysely"].types.import` to the new ESM declarations

## Rationale
TypeScript NodeNext treats `pgvector` as CJS, so `pgvector/kysely` currently resolves `kysely` types via the CJS path. ESM consumers resolve `kysely` via the ESM path, which makes `RawBuilder` incompatible. Providing an ESM `.d.mts` and an `import` types condition aligns the types for ESM users.

Fixes #29.

## Testing
- not run (type-only change)
