### PR TITLE
fix: Add TypeScript type definitions for Sequelize DataTypes (VECTOR, HALFVEC, SPARSEVEC)

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -1,3 +1,38 @@
+import type { DataType } from 'sequelize';
+
+// VECTOR data type constructor
+export interface VectorDataTypeConstructor {
+  new (dimensions?: number): DataType;
+  (dimensions?: number): DataType;
+}
+
+// HALFVEC data type constructor
+export interface HalfvecDataTypeConstructor {
+  new (dimensions?: number): DataType;
+  (dimensions?: number): DataType;
+}
+
+// SPARSEVEC data type constructor
+export interface SparsevecDataTypeConstructor {
+  new (dimensions?: number): DataType;
+  (dimensions?: number): DataType;
+}
+
+// Module augmentation to extend Sequelize DataTypes
+declare module 'sequelize' {
+  namespace DataTypes {
+    const VECTOR: VectorDataTypeConstructor;
+    const HALFVEC: HalfvecDataTypeConstructor;
+    const SPARSEVEC: SparsevecDataTypeConstructor;
+    
+    namespace postgres {
+      const VECTOR: VectorDataTypeConstructor;
+      const HALFVEC: HalfvecDataTypeConstructor;
+      const SPARSEVEC: SparsevecDataTypeConstructor;
+    }
+  }
+}
+
 export function registerType(Sequelize: any): void;
 export function registerTypes(Sequelize: any): void;
 export function l2Distance(column: any, value: any, sequelize: any): any;


### PR DESCRIPTION
## Problem
TypeScript users get type errors when using `DataTypes.VECTOR()`, `DataTypes.HALFVEC()`, 
or `DataTypes.SPARSEVEC()` because the type definitions don't augment Sequelize's DataTypes.

Error: `Property 'VECTOR' does not exist on type 'typeof DataTypes'`

## Solution
Added module augmentation in `types/sequelize/index.d.ts` to extend Sequelize's 
`DataTypes` namespace with the vector types.

## Changes
- Added `VectorDataTypeConstructor`, `HalfvecDataTypeConstructor`, `SparsevecDataTypeConstructor` interfaces
- Added module augmentation for `sequelize` to declare the types on `DataTypes` namespace
- Supports both `DataTypes.VECTOR(3)` and `DataTypes.postgres.VECTOR(3)`